### PR TITLE
MKL fix for mac

### DIFF
--- a/FindIntelMKL.cmake
+++ b/FindIntelMKL.cmake
@@ -26,6 +26,10 @@ if( "scalapack" IN_LIST IntelMKL_FIND_COMPONENTS AND NOT ("blacs" IN_LIST IntelM
   list(APPEND IntelMKL_FIND_COMPONENTS "blacs" )
 endif()
 
+if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64")
+  message( FATAL_ERROR "IntelMKL is not supported for ARM architectures" )
+endif()
+
 # MKL lib names
 if( IntelMKL_PREFERS_STATIC )
   set( IntelMKL_LP64_LIBRARY_NAME       "libmkl_intel_lp64.a"   )

--- a/FindIntelMKL.cmake
+++ b/FindIntelMKL.cmake
@@ -27,7 +27,7 @@ if( "scalapack" IN_LIST IntelMKL_FIND_COMPONENTS AND NOT ("blacs" IN_LIST IntelM
 endif()
 
 if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64")
-  message( FATAL_ERROR "IntelMKL is not supported for ARM architectures" )
+  message( WARNING "IntelMKL is not supported for ARM architectures" )
 endif()
 
 # MKL lib names

--- a/FindIntelMKL.cmake
+++ b/FindIntelMKL.cmake
@@ -364,6 +364,7 @@ if( IntelMKL_LIBRARY AND IntelMKL_THREAD_LIBRARY AND IntelMKL_CORE_LIBRARY )
 
   if( IntelMKL_PREFERS_STATIC )
 
+  if(NOT "${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Darwin")
     list( PREPEND IntelMKL_BLAS_LAPACK_LIBRARIES "-Wl,--start-group" )
     list( APPEND  IntelMKL_BLAS_LAPACK_LIBRARIES "-Wl,--end-group"   )
 
@@ -371,6 +372,7 @@ if( IntelMKL_LIBRARY AND IntelMKL_THREAD_LIBRARY AND IntelMKL_CORE_LIBRARY )
       list( PREPEND IntelMKL_BLACS_LIBRARIES "-Wl,--start-group" )
       list( APPEND  IntelMKL_BLACS_LIBRARIES "-Wl,--end-group"   )
     endif()
+  endif()
 
     if( "scalapack" IN_LIST IntelMKL_FIND_COMPONENTS )
       set( IntelMKL_ScaLAPACK_LIBRARIES 


### PR DESCRIPTION
macOS linker does not support `--{start,end}-group` 
The IntelMKL link line advisor also does not suggest these options when macOS is selected.